### PR TITLE
feat: add the ability for the baseUri to be passed when initializing the Novu sdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,17 +48,37 @@ composer require unicodeveloper/novu
 
 ## Usage
 
-First, create an instance of the **Novu SDK** like so:
+To interact with the **Novu SDK**, you can instantiate it with either just an API key or with a configuration array that includes the API key and a custom base URI.
+
+### Using just the API key:
 
 ```php
 use Novu\SDK\Novu;
 
-$novu = new Novu(<INSERT_API_KEY_HERE>);
+$novu = new Novu('YOUR_API_KEY_HERE');
 
 // Sign up on https://web.novu.co and grab your API key from https://web.novu.co/settings
 ```
 
-Now, you can use the `Novu` instance to perform all the actions that Novu's API provides. 
+### Using a configuration array:
+
+If you need to specify a custom base URI (e.g., if you are pointing to a staging environment or a local development setup), you can pass an array with the `apiKey` and `baseUri`:
+
+```php
+use Novu\SDK\Novu;
+
+$config = [
+    'apiKey' => 'YOUR_API_KEY_HERE',
+    'baseUri' => 'https://custom-api-url.com/v1/'
+];
+
+$novu = new Novu($config);
+
+// Get started with self-hosted Novu here https://docs.novu.co/overview/docker-deploy
+```
+
+Once the `Novu` instance is created, you can use it to perform all the actions that Novu's API provides.
+
 
 ## EVENTS
 

--- a/src/Novu.php
+++ b/src/Novu.php
@@ -3,6 +3,7 @@
 namespace Novu\SDK;
 
 use GuzzleHttp\Client as HttpClient;
+use InvalidArgumentException;
 use Novu\SDK\Exceptions\IsNull;
 use Novu\SDK\Exceptions\IsEmpty;
 
@@ -36,7 +37,7 @@ class Novu
      *
      * @var string
      */
-    protected $baseUri = 'https://api.novu.co/v1/';
+    protected $baseUri;
 
     /**
      * The Guzzle HTTP Client instance.
@@ -55,28 +56,37 @@ class Novu
     /**
      * Create a new Novu instance.
      *
-     * @param  string|null  $apiKey
+     * @param  array|string|null  $apiKey
      * @param  \GuzzleHttp\Client|null  $guzzle
      * @return void
      */
-    public function __construct($apiKey = null, HttpClient $client = null)
+    public function __construct($config = [], HttpClient $client = null)
     {
-        if ( is_null($apiKey)) {
+        // Default values
+        $defaultBaseUri = 'https://api.novu.co/v1/';
+    
+        if (is_string($config)) {
+            $apiKey = $config;
+            $baseUri = $defaultBaseUri;
+        } elseif (is_array($config)) {
+            $apiKey = $config['apiKey'] ?? null;
+            $baseUri = $config['baseUri'] ?? $defaultBaseUri;
+        } else {
+            throw new InvalidArgumentException("Invalid configuration provided.");
+        }
+    
+        if (is_null($apiKey)) {
             throw IsNull::make('API KEY');
         }
-
-        if( empty($apiKey)) {
-            throw isEmpty::make('API KEY');
+    
+        if (empty($apiKey)) {
+            throw IsEmpty::make('API KEY');
         }
-
-        if (! is_null($apiKey)) {
-            $this->setApiKey($apiKey, $client);
-        }
-
-        if (! is_null($client)) {
-            $this->client = $client;
-        }
+    
+        $this->baseUri = $baseUri;
+        $this->setApiKey($apiKey, $client);
     }
+    
 
     /**
      * Set the api key and setup the client request object.


### PR DESCRIPTION
closes #29 

This approach remains backward compatible because if you just pass a string as the ApiKey it will use it as it did before.

Having the option to pass in an array config leaves the flexibility for more configurable params to be passed in later on.

FYI: running `composer lint` changes like 40 files. It seem that hasn't been used as a part of the workflow so far so I opted not to run it to keep the PR simple. 