### PR TITLE
FIX #43 Link to Api Docs in readme needs updated to correct link

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ composer require unicodeveloper/novu
 
 * [Installation](#installation)
 * [Usage](#usage)
-    * [Novu API Reference](https://docs.novu.co/api/overview/)
+    * [Novu API Reference](https://docs.novu.co/api-reference/)
     * [Events](#events)
     * [Subscribers](#subscribers)
     * [Topics](#topics)


### PR DESCRIPTION
Link to Api Docs in readme needs updated to correct link  #43 
I have updated the link with current documentation.
 https://docs.novu.co/api-reference/