### PR TITLE
Fix: filter layouts return data

### DIFF
--- a/src/Actions/ManagesLayout.php
+++ b/src/Actions/ManagesLayout.php
@@ -15,7 +15,9 @@ trait ManagesLayout
     public function filterLayouts(array $queryParams = [])
     {
         $layouts = $this->get("layouts", $queryParams);
-        $layouts['data'] = array_map(function($value){ new Layout($value, $this); }, $layouts['data']);
+        $layouts['data'] = array_map(function ($value) {
+            return new Layout($value, $this);
+        }, $layouts['data']);
 
         return $layouts;
     }


### PR DESCRIPTION
Currently data returning `null`. 
```php
[
  "page" => 0
  "totalCount" => 2
  "pageSize" => 10
  "data" => [
    0 => null
    1 => null
  ]
]
``` 