### PR TITLE
Feat/global preferences

### DIFF
--- a/src/Actions/ManagesSubscribers.php
+++ b/src/Actions/ManagesSubscribers.php
@@ -126,6 +126,33 @@ trait ManagesSubscribers
         return new Subscriber($subscriber, $this);
     }
 
+    /* Fetch a subscriber preferences
+    *
+    * @param  string  $subscriberId
+    * @return \Novu\SDK\Resources\Subscriber
+    */
+   public function getSubscriberGlobalPreferences($subscriberId)
+   {
+       $preferences = $this->get("subscribers/{$subscriberId}/preferences/global")['data'];
+
+       return new Subscriber($preferences, $this);
+   }
+
+       /**
+     * Update a given subscribers global preferences [ Come back to this---->]
+     *
+     * @param  string $subscriberId
+     * @param  string $templateId
+     * @param  array  $data
+     * @return \Novu\SDK\Resources\Subscriber
+     */
+    public function updateSubscriberGlobalPreference($subscriberId, $templateId, array $data)
+    {
+        $subscriber = $this->patch("subscribers/{$subscriberId}/preferences", $data)['data'];
+
+        return new Subscriber($subscriber, $this);
+    }
+
     /**
      * Update subscriber online status
      *

--- a/src/Actions/ManagesSubscribers.php
+++ b/src/Actions/ManagesSubscribers.php
@@ -147,7 +147,7 @@ trait ManagesSubscribers
      * @param  array  $data
      * @return \Novu\SDK\Resources\Subscriber
      */
-    public function updateSubscriberGlobalPreference($subscriberId, $templateId, array $data)
+    public function updateSubscriberGlobalPreference($subscriberId, array $data)
     {
         $subscriber = $this->patch("subscribers/{$subscriberId}/preferences", $data)['data'];
 

--- a/src/Actions/ManagesSubscribers.php
+++ b/src/Actions/ManagesSubscribers.php
@@ -126,11 +126,12 @@ trait ManagesSubscribers
         return new Subscriber($subscriber, $this);
     }
 
-    /* Fetch a subscriber preferences
-    *
-    * @param  string  $subscriberId
-    * @return \Novu\SDK\Resources\Subscriber
-    */
+    /**
+     * Fetch a subscribers global preferences
+     *
+     * @param  string  $subscriberId
+     * @return \Novu\SDK\Resources\Subscriber
+     */
    public function getSubscriberGlobalPreferences($subscriberId)
    {
        $preferences = $this->get("subscribers/{$subscriberId}/preferences/global")['data'];
@@ -138,7 +139,7 @@ trait ManagesSubscribers
        return new Subscriber($preferences, $this);
    }
 
-       /**
+    /**
      * Update a given subscribers global preferences [ Come back to this---->]
      *
      * @param  string $subscriberId


### PR DESCRIPTION
There's routes to get and set Global Preferences and so these are functions to interact with those.

One little note on the comment `[ Come back to this---->]` on line 143.

I copied that function from the `updateSubscriberPreference()` function and just changed the route so if there was anything to actually come back to on that one I'd assume the same thing should be looked at here too. 

I can remove both comments if we don't ever need to come back that though. 